### PR TITLE
Update chart range options

### DIFF
--- a/src/components/Chart/ChartControls.tsx
+++ b/src/components/Chart/ChartControls.tsx
@@ -3,7 +3,7 @@ import { useContext } from 'react';
 import { PriceContext } from '@/context/PriceContext';
 import { ControlsWrapper, RangeButton } from './Chart.styles';
 
-const ranges = ['1d','3d','1w','1m','6m','1y','max'] as const;
+const ranges = ['1h', '1d', '1m'] as const;
 
 export default function ChartControls() {
   const { range, setRange } = useContext(PriceContext);

--- a/src/context/PriceContext.tsx
+++ b/src/context/PriceContext.tsx
@@ -3,18 +3,20 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchSummary, fetchChart } from '@/services/api';
 import type { PriceSummary, PricePoint } from '@/types/price';
 
+type ChartRange = '1h' | '1d' | '1m';
+
 type PriceContextType = {
   summary?: PriceSummary;
   chartData?: PricePoint[];
   isLoading: boolean;
-  range: string;
-  setRange: (r: string) => void;
+  range: ChartRange;
+  setRange: (r: ChartRange) => void;
 };
 
 export const PriceContext = createContext<PriceContextType>({} as any);
 
 export function PriceProvider({ children }: { children: ReactNode }) {
-  const [range, setRange] = React.useState<'1d'|'3d'|'1w'|'1m'|'6m'|'1y'|'max'>('1w');
+  const [range, setRange] = React.useState<ChartRange>('1d');
   const summaryQuery = useQuery<PriceSummary>({
     queryKey: ['summary'],
     queryFn: fetchSummary,

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -12,13 +12,24 @@ export const fetchSummary = async (): Promise<PriceSummary> => {
 };
 
 export const fetchChart = async (
-  range: '1d' | '3d' | '1w' | '1m' | '6m' | '1y' | 'max',
+  range: '1h' | '1d' | '1m',
 ): Promise<PricePoint[]> => {
-  // generate dummy sine chart:
-  console.log({range})
+  const endpoints = {
+    '1h': '/chart/1h',
+    '1d': '/chart/1d',
+    '1m': '/chart/1m',
+  } as const;
+
+  // Uncomment the following lines when a real API is available
+  // const response = await client.get(endpoints[range]);
+  // return response.data;
+
+  // Fallback: generate dummy sine chart
   const now = Date.now();
-  return Array.from({ length: 50 }).map((_, i) => ({
-    timestamp: now - (50 - i) * 3600 * 1000,
-    price: 63000 + 500 * Math.sin((i / 50) * Math.PI * 2),
+  const length = range === '1h' ? 60 : range === '1d' ? 24 : 30;
+  const interval = 3600 * 1000;
+  return Array.from({ length }).map((_, i) => ({
+    timestamp: now - (length - i) * interval,
+    price: 63000 + 500 * Math.sin((i / length) * Math.PI * 2),
   }));
 };


### PR DESCRIPTION
## Summary
- simplify chart ranges
- support new range type in PriceContext
- update fetchChart to return data for 1h/1d/1m ranges

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*