### PR TITLE
Add loading skeletons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route, NavLink } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 import { PriceProvider } from '@/context/PriceContext';
 import Summary from '@/pages/Summary';
 import ChartPage from '@/pages/ChartPage';

--- a/src/components/Chart/CombinedChart.tsx
+++ b/src/components/Chart/CombinedChart.tsx
@@ -130,7 +130,7 @@ export default function CombinedChart({ data }: Props) {
             r={6}
             fill="#5c6bc0"
             stroke="none"
-            label={({ x, y }) => {
+            label={() => {
               const text = `$${last.price.toFixed(2)}`;
               const pad = 6, fs = 12;
               const w = text.length * fs * 0.6 + pad * 2;

--- a/src/components/Header/PriceHeader.tsx
+++ b/src/components/Header/PriceHeader.tsx
@@ -1,12 +1,21 @@
 import React from 'react';
 import { useContext } from 'react';
 import { PriceContext } from '@/context/PriceContext';
+import Skeleton from '@/components/Skeleton';
 import { HeaderWrapper, Price, Change, PriceWithSymbol, Symbol } from './PriceHeader.styles';
 
 export default function PriceHeader() {
   const { summary, isLoading } = useContext(PriceContext);
 
-  if (isLoading || !summary) return <HeaderWrapper>Loading...</HeaderWrapper>;
+  if (isLoading || !summary)
+    return (
+      <HeaderWrapper>
+        <PriceWithSymbol>
+          <Skeleton width="200px" height="70px" />
+        </PriceWithSymbol>
+        <Skeleton width="120px" height="24px" />
+      </HeaderWrapper>
+    );
 
   return (
     <HeaderWrapper>

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,17 @@
+import styled, { keyframes } from 'styled-components';
+
+const pulse = keyframes`
+  0% { opacity: 1; }
+  50% { opacity: 0.4; }
+  100% { opacity: 1; }
+`;
+
+const Skeleton = styled.div<{ width?: string; height?: string }>`
+  background-color: #e0e0e0;
+  border-radius: 4px;
+  width: ${({ width }) => width ?? '100%'};
+  height: ${({ height }) => height ?? '1em'};
+  animation: ${pulse} 1.5s ease-in-out infinite;
+`;
+
+export default Skeleton;

--- a/src/context/PriceContext.tsx
+++ b/src/context/PriceContext.tsx
@@ -13,7 +13,13 @@ type PriceContextType = {
   setRange: (r: ChartRange) => void;
 };
 
-export const PriceContext = createContext<PriceContextType>({} as any);
+export const PriceContext = createContext<PriceContextType>({
+  summary: undefined,
+  chartData: undefined,
+  isLoading: false,
+  range: '1d',
+  setRange: () => {},
+});
 
 export function PriceProvider({ children }: { children: ReactNode }) {
   const [range, setRange] = React.useState<ChartRange>('1d');

--- a/src/pages/ChartPage.tsx
+++ b/src/pages/ChartPage.tsx
@@ -2,11 +2,23 @@ import React, { useContext } from 'react';
 import { PriceContext } from '@/context/PriceContext';
 import CombinedChart from '@/components/Chart/CombinedChart';
 import ChartControls from '@/components/Chart/ChartControls';
+import Skeleton from '@/components/Skeleton';
+import { ControlsWrapper } from '@/components/Chart/Chart.styles';
 
 export default function ChartPage() {
   const { chartData, isLoading } = useContext(PriceContext);
 
-  if (isLoading || !chartData) return <p>Loading chart…</p>;
+  if (isLoading || !chartData)
+    return (
+      <div>
+        <ControlsWrapper>
+          <Skeleton width="40px" height="32px" />
+          <Skeleton width="40px" height="32px" />
+          <Skeleton width="40px" height="32px" />
+        </ControlsWrapper>
+        <Skeleton height="450px" />
+      </div>
+    );
 
   return (
     <div>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -14,11 +14,11 @@ export const fetchSummary = async (): Promise<PriceSummary> => {
 export const fetchChart = async (
   range: '1h' | '1d' | '1m',
 ): Promise<PricePoint[]> => {
-  const endpoints = {
-    '1h': '/chart/1h',
-    '1d': '/chart/1d',
-    '1m': '/chart/1m',
-  } as const;
+  // const endpoints = {
+  //   '1h': '/chart/1h',
+  //   '1d': '/chart/1d',
+  //   '1m': '/chart/1m',
+  // } as const;
 
   // Uncomment the following lines when a real API is available
   // const response = await client.get(endpoints[range]);
@@ -31,5 +31,6 @@ export const fetchChart = async (
   return Array.from({ length }).map((_, i) => ({
     timestamp: now - (length - i) * interval,
     price: 63000 + 500 * Math.sin((i / length) * Math.PI * 2),
+    volume: Math.floor(Math.random() * 1000),
   }));
 };


### PR DESCRIPTION
## Summary
- add a small Skeleton component for loading placeholders
- show skeleton placeholders in `PriceHeader` and `ChartPage`
- clean up unused imports and lint warnings
- fix dummy API return type

## Testing
- `npm run lint`
- `npm run build`